### PR TITLE
specifying node and npm versions

### DIFF
--- a/lib/generators/breakfast/install_generator.rb
+++ b/lib/generators/breakfast/install_generator.rb
@@ -4,9 +4,11 @@ module Breakfast
   module Generators
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path('../templates', __FILE__)
+      NODE_VERSION = 'v4.1.1'
+      NPM_VERSION  = '3.10.6'
 
       def install
-        if prerequisites_installed?
+        if node_prerequisites_installed?
           create_brunch_config
           create_package_json
           create_directory_structure
@@ -27,7 +29,7 @@ module Breakfast
 
             ---> ERROR - MISSING NODE & NPM
 
-            ---> Node & npm are required to run Breakfast.
+            ---> Node version >= #{NODE_VERSION} & npm version >= #{NPM_VERSION} are required to run Breakfast.
             ---> Please install them before attempting to continue.
             ---> https://nodejs.org
             ---> https://npmjs.org
@@ -38,8 +40,12 @@ module Breakfast
 
       private
 
-      def prerequisites_installed?
-        `which node`.present? && `which npm`.present?
+      def node_prerequisites_installed?
+        `which node`.present? && `which npm`.present? && node_versions_are_satisfactory?
+      end
+
+      def node_versions_are_satisfactory?
+        `node -v` >= NODE_VERSION && `npm -v` >= NPM_VERSION
       end
 
       def create_brunch_config


### PR DESCRIPTION
When installing breakfast, node and npm are checked for existence but not for a correct version.  The Breakfast Installation will proceed and running the server will give a cryptic error message that eventually results from using an old NPM version (possibly Node as well?).

Here is a possible solution to check for satisfactory node/npm versions.  The specific versions are based on my ability to successfully run a server with a react component using breakfast.

I lost the exact error, but it might have been either
```
$ bin/rails s
=> Booting Puma
=> Rails 5.0.0.1 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
Exiting
/Users/Josh/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/breakfast-0.1.1/lib/breakfast/railtie.rb:26:in `spawn': No such file or directory - brunch (Errno::ENOENT)
	from /Users/Josh/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/breakfast-0.1.1/lib/breakfast/railtie.rb:26:in `block in <class:Railtie>'
```

or 
```
E, [2016-09-11T11:41:03.412038 #1584] ERROR -- : exception while processing events: undefined method `fetch' for nil:NilClass Backtrace:
 -- /Users/Josh/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actioncable-5.0.0.1/lib/action_cable/server/configuration.rb:24:in `pubsub_adapter'```