### PR TITLE
0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,58 @@
 # CHANGE LOG
 
+### 0.4.0 - 2016-11-14
+#### Upgrading to `0.4.0` from `0.3.0`
+- Update gem with `bundle update breakfast`
+- Bump the `breakfast-rails` version in `package.json` to `0.4.0`
+- Run `npm install`
+
+*Note* Now by default asset fingerprinting will be on by default in production.
+A copy of each with the original filename will be present as well, so any
+hard-coded links to assets will still work correctly.
+
+#### Added
+- Asset Digests. Now when deploying assets will have fingerprints added to their
+  file names. This allows browsers to aggressively cache your assets.
+- New Option: `breakfast.manifest.digest`. Defaults to false in development /
+  test and true everywhere else. When true, enables Rails to serve fingerprinted
+  assets.
+- Rake Commands to trigger certain behavior:
+  - `breakfast:assets:build`
+    Manually run a compilation step.
+  - `breakfast:assets:build_production`
+    Manually trigger a production build. This will cause assets to get minified.
+  - `breakfast:assets:digest`
+    Run through your compiled assets and add a fingerprint to each one. Creates
+    a copy, leaving a file with the original filename and a duplicate with an
+    md5 fingerprint.
+  - `breakfast:assets:clean`
+    Removes any assets from the output folder that are not specified in the
+    manifest file (removes out of date files).
+  - `breakfast:assets:nuke`
+    Removes manifest and fingerprinted assets from the output folder.
+- New Capistrano Option: `:breakfast_npm_install_command`
+  Defaults to just `install`. Can be overridden to redirect output to dev/null.
+  Example:
+
+  ```
+  set :breakfast_npm_install_command, "install > /dev/null 2>&1"
+  ```
+
+#### Changes
+- Fixed small CSS issue if box-sizing is not set border-box globally.
+
+
+#### Contributors
+Many many thanks to the contributors for this release!
+- [@patkoperwas](https://github.com/patkoperwas)
+- [@mikeastock](https://github.com/mikeastock)
+- [@HParker](https://github.com/HParker)
+
+
 ## 0.3.1 - 2016-10-19
 - Better support for determining if Server is running. Using puma, passneger,
   etc. instead of the default rails server command now work.
+
 
 ## 0.3.0 - 2016-09-28
 

--- a/README.md
+++ b/README.md
@@ -15,46 +15,48 @@ See the official docs at
 
 View updates in the [CHANGELOG](https://github.com/devlocker/breakfast/blob/master/CHANGELOG.md)
 
-### Latest Patch `0.3.1`
-- Allows Breakfast to run when Rails is started outside of bin/rails server,
-  i.e. bundle exec puma, passenger, thin, etc.
-
-### Latest Release `0.3.0`
+### Latest Release `0.4.0`
 #### Added
-- New status bar that allows the user to switch reload strategies on the fly
-- Support for Haml & Slim files (without .html extension)
-- Reloading on ruby file changes.
-- Specify minimum Node & NPM versions when installing (avoid awkward and none
-  descriptive error messages)
-- NPM binary path for Capistrano
+- Asset Digests. Now when deploying assets will have fingerprints added to their
+  file names. This allows browsers to aggressively cache your assets.
+- New Option: `breakfast.manifest.digest`. Defaults to false in development /
+  test and true everywhere else. When true, enables Rails to serve fingerprinted
+  assets.
+- Rake Commands to trigger certain behavior:
+  - `breakfast:assets:build`
+    Manually run a compilation step.
+  - `breakfast:assets:build_production`
+    Manually trigger a production build. This will cause assets to get minified.
+  - `breakfast:assets:digest`
+    Run through your compiled assets and add a fingerprint to each one. Creates
+    a copy, leaving a file with the original filename and a duplicate with an
+    md5 fingerprint.
+  - `breakfast:assets:clean`
+    Removes any assets from the output folder that are not specified in the
+    manifest file (removes out of date files).
+  - `breakfast:assets:nuke`
+    Removes manifest and fingerprinted assets from the output folder.
+- New Capistrano Option: `:breakfast_npm_install_command`
+  Defaults to just `install`. Can be overridden to redirect output to dev/null.
+  Example:
+
+  ```
+  set :breakfast_npm_install_command, "install > /dev/null 2>&1"
+  ```
 
 #### Changes
-- config.breakfast.view_folders change to config.breakfast.source_code_folders.
-  Change brought about by need to trigger reloads when Ruby source code changes.
-
-#### Removed
-- config.breakfast.view_folders is no longer supported. Deprecated in favor of
-  source_code_folders option.
+- Fixed small CSS issue if box-sizing is not set border-box globally.
 
 
 ### Upgrading
-#### Upgrading to `0.3.0` from `0.2.0`
+#### Upgrading to `0.4.0` from `0.3.0`
 - Update gem with `bundle update breakfast`
-- Bump the `breakfast-rails` version in `package.json` to `0.3.1`
+- Bump the `breakfast-rails` version in `package.json` to `0.4.0`
 - Run `npm install`
-- If you have modified the `config.breakfast.view_folders` option you will need
-  to replace it. The new option is `config.breakfast.source_code_folders` and it
-  defaults to `[Rails.root.join("app")]`. If you have view or Ruby files that
-  you would like to trigger reloads outside of the `app` folder then append
-  those paths by adding:
 
-  ```
-  config.breakfast.source_code_folders << Rails.root.join("lib")
-  ```
-
-  To which ever environment you want `Breakfast` to run in
-  (probably `config/environments/development.rb`).
-
+*Note* Now by default asset fingerprinting will be on by default in production.
+A copy of each with the original filename will be present as well, so any
+hard-coded links to assets will still work correctly.
 
 ### Contributing
 Bug reports and pull requests are welcome on GitHub at

--- a/lib/breakfast.rb
+++ b/lib/breakfast.rb
@@ -1,13 +1,17 @@
 require "breakfast/version"
-require "breakfast/live_reload_channel"
-require "breakfast/status_channel"
-require "breakfast/view_helper"
+
 require "breakfast/brunch_watcher"
 require "breakfast/compilation_listener"
+require "breakfast/live_reload_channel"
+require "breakfast/manifest"
+require "breakfast/status_channel"
+require "breakfast/view_helper"
 
 module Breakfast
   STATUS_CHANNEL = "breakfast_status".freeze
   RELOAD_CHANNEL = "breakfast_live_reload".freeze
+  BUILD_COMMAND = "./node_modules/brunch/bin/brunch build".freeze
+  PRODUCTION_BUILD_COMMAND = "./node_modules/brunch/bin/brunch build --production".freeze
 end
 
 require "breakfast/railtie" if defined?(Rails)

--- a/lib/breakfast/capistrano.rb
+++ b/lib/breakfast/capistrano.rb
@@ -1,6 +1,6 @@
-require 'capistrano/version'
+require "capistrano/version"
 
-if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
+if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new("3.0.0")
   load File.expand_path("../capistrano/tasks/breakfast.rake", __FILE__)
 else
   raise "Requires Capistrano V3"

--- a/lib/breakfast/capistrano/tasks/breakfast.rake
+++ b/lib/breakfast/capistrano/tasks/breakfast.rake
@@ -3,13 +3,28 @@ namespace :breakfast do
   task :compile do
     on roles fetch(:breakfast_roles) do |host|
       within release_path do
-        execute fetch(:breakfast_npm_path).to_sym, "install"
-        execute "node_modules/brunch/bin/brunch", "build --production"
+        with rails_env: "#{fetch(:rails_env) || fetch(:stage)}" do
+          execute fetch(:breakfast_npm_path).to_sym, fetch(:breakfast_npm_install_command)
+          execute :rails, "breakfast:assets:build_production"
+          execute :rails, "breakfast:assets:digest"
+        end
+      end
+    end
+  end
+
+  desc "Clean out old assets"
+  task :clean do
+    on roles fetch(:breakfast_roles) do |host|
+      within release_path do
+        with rails_env: "#{fetch(:rails_env) || fetch(:stage)}" do
+          execute :rails, "breakfast:assets:clean"
+        end
       end
     end
   end
 
  after "deploy:updated", "breakfast:compile"
+ after "deploy:published", "breakfast:clean"
 end
 
 
@@ -17,5 +32,6 @@ namespace :load do
   task :defaults do
     set :breakfast_roles, -> { :web }
     set :breakfast_npm_path, "/usr/bin/npm"
+    set :breakfast_npm_install_command, "install"
   end
 end

--- a/lib/breakfast/compilation_listener.rb
+++ b/lib/breakfast/compilation_listener.rb
@@ -3,9 +3,9 @@ module Breakfast
     ASSET_EXTENSIONS = ["css", "js"].freeze
     SOURCE_CODE_EXTENSIONS = ["rb", "html", "haml", "slim"].freeze
 
-    def self.start(asset_output_folders:, source_code_folders:)
-      asset_listener = 
-        ::Listen.to(*asset_output_folders) do |modified, added, removed|
+    def self.start(asset_output_folder:, source_code_folders:)
+      asset_listener =
+        ::Listen.to(asset_output_folder) do |modified, added, removed|
           files = modified + added + removed
 
           ASSET_EXTENSIONS.each do |extension|
@@ -15,7 +15,7 @@ module Breakfast
           end
         end
 
-      rails_listener = 
+      rails_listener =
         ::Listen.to(*source_code_folders) do |modified, added, removed|
           files = modified + added + removed
 

--- a/lib/breakfast/manifest.rb
+++ b/lib/breakfast/manifest.rb
@@ -1,0 +1,115 @@
+require "json"
+require "digest"
+require "fileutils"
+
+module Breakfast
+  class Manifest
+    MANIFEST_REGEX = /^\.breakfast-manifest-[0-9a-f]{32}.json$/
+    SPROCKETS_MANIFEST_REGEX = /^\.sprockets-manifest-[0-9a-f]{32}.json$/
+    FINGERPRINT_REGEX = /-[0-9a-f]{32}./
+
+    attr_reader :base_dir, :manifest_path, :cache
+    def initialize(base_dir:)
+      FileUtils.mkdir_p(base_dir)
+
+      @base_dir = Pathname.new(base_dir)
+      @manifest_path = find_manifest_or_create
+      @cache = update_cache!
+    end
+
+    def asset(path)
+      cache[path]
+    end
+
+    # The #digest! method will run through all of the compiled assets and
+    # create a copy of each asset with a digest fingerprint. This fingerprint
+    # will change whenever the file contents change. This allows us to use HTTP
+    # headers to cache these assets as we will be able to reliably know when
+    # they change.
+    #
+    # These fingerprinted files are copies of the original. The originals are
+    # not removed and still available should the need arise to serve a
+    # non-fingerprinted asset.
+    #
+    # Example manifest:
+    # {
+    #   app.js => app-76c6ee161ba431e823301567b175acda.js,
+    #   images/logo.png => images/logo-869269cdf1773ff0dec91bafb37310ea.png,
+    # }
+    #
+    # Resulting File Structure:
+    # - /
+    #   - app.js
+    #   - app-76c6ee161ba431e823301567b175acda.js
+    #   - images/
+    #     - logo.png
+    #     - logo-869269cdf1773ff0dec91bafb37310ea.png
+    def digest!
+      assets = asset_paths.map do |path|
+        digest = Digest::MD5.new
+        digest.update(File.read("#{base_dir}/#{path}"))
+
+        digest_path = "#{path.sub_ext('')}-#{digest.hexdigest}#{File.extname(path)}"
+
+        FileUtils.cp("#{base_dir}/#{path}", "#{base_dir}/#{digest_path}")
+
+        [path, digest_path]
+      end
+
+      File.open(manifest_path, "w") do |manifest|
+        manifest.write(assets.to_h.to_json)
+      end
+
+      update_cache!
+    end
+
+    # Remove any files not directly referenced by the manifest.
+    def clean!
+      files_to_keep = cache.keys.concat(cache.values)
+
+      if (sprockets_manifest = Dir.entries("#{base_dir}").detect { |entry| entry =~ SPROCKETS_MANIFEST_REGEX })
+        files_to_keep.concat(JSON.parse(File.read("#{base_dir}/#{sprockets_manifest}"))["files"].keys)
+      end
+
+      Dir["#{base_dir}/**/*"].each do |path|
+        next if File.directory?(path) || files_to_keep.include?(Pathname(path).relative_path_from(base_dir).to_s)
+
+        FileUtils.rm(path)
+      end
+    end
+
+    # Remove manifest, any fingerprinted files.
+    def nuke!
+      Dir["#{base_dir}/**/*"]
+        .select { |path| path =~ FINGERPRINT_REGEX }
+        .each { |file| FileUtils.rm(file) }
+
+      FileUtils.rm(manifest_path)
+    end
+
+    private
+
+    def update_cache!
+      @cache = JSON.parse(File.read(manifest_path))
+    end
+
+    # Creates a or finds a manifest file in a given directory. The manifest
+    # file is is prefixed with a dot ('.') and given a random string to ensure
+    # the file is not served or easily discoverable.
+    def find_manifest_or_create
+      if (manifest = Dir.entries("#{base_dir}").detect { |entry| entry =~ MANIFEST_REGEX })
+        "#{base_dir}/#{manifest}"
+      else
+        manifest = "#{base_dir}/.breakfast-manifest-#{SecureRandom.hex(16)}.json"
+        File.open(manifest, "w") { |manifest| manifest.write({}.to_json) }
+        manifest
+      end
+    end
+
+    def asset_paths
+      Dir["#{base_dir}/**/*"]
+        .reject { |path| File.directory?(path) || path =~ FINGERPRINT_REGEX }
+        .map { |file| Pathname(file).relative_path_from(base_dir) }
+    end
+  end
+end

--- a/lib/breakfast/version.rb
+++ b/lib/breakfast/version.rb
@@ -1,3 +1,3 @@
 module Breakfast
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/lib/breakfast/view_helper.rb
+++ b/lib/breakfast/view_helper.rb
@@ -19,5 +19,16 @@ module Breakfast
         end
       end
     end
+
+    include ActionView::Helpers::AssetUrlHelper
+    include ActionView::Helpers::AssetTagHelper
+
+    def compute_asset_path(path, options = {})
+      if Rails.configuration.breakfast.digest && Rails.configuration.breakfast.manifest.asset(path)
+        path = Rails.configuration.breakfast.manifest.asset(path)
+      end
+
+      super(path, options)
+    end
   end
 end

--- a/lib/generators/breakfast/install_generator.rb
+++ b/lib/generators/breakfast/install_generator.rb
@@ -3,9 +3,9 @@ require "rails/generators"
 module Breakfast
   module Generators
     class InstallGenerator < Rails::Generators::Base
-      source_root File.expand_path('../templates', __FILE__)
-      NODE_VERSION = 'v4.1.1'
-      NPM_VERSION  = '3.10.6'
+      source_root File.expand_path("../templates", __FILE__)
+      NODE_VERSION = "v4.1.1"
+      NPM_VERSION  = "3.10.6"
 
       def install
         if node_prerequisites_installed?

--- a/lib/tasks/breakfast.rake
+++ b/lib/tasks/breakfast.rake
@@ -1,0 +1,61 @@
+require "rake"
+require "breakfast"
+
+namespace :breakfast do
+  namespace :assets do
+    desc "Build assets"
+    task :build => :environment do
+      exec(Breakfast::BUILD_COMMAND)
+    end
+
+    desc "Build assets for production"
+    task :build_production => :environment do
+      exec(Breakfast::PRODUCTION_BUILD_COMMAND)
+    end
+
+    desc "Add a digest to non-fingerprinted assets"
+    task :digest => :environment do
+      if Rails.configuration.breakfast.manifest
+        Rails.configuration.breakfast.manifest.digest!
+      else
+        raise Breakfast::ManifestDisabledError
+      end
+    end
+
+    desc "Remove out of date assets"
+    task :clean => :environment do
+      if Rails.configuration.breakfast.manifest
+        Rails.configuration.breakfast.manifest.clean!
+      else
+        raise Breakfast::ManifestDisabledError
+      end
+    end
+
+    desc "Remove manifest and fingerprinted assets"
+    task :nuke => :environment do
+      if Rails.configuration.breakfast.manifest
+        Rails.configuration.breakfast.manifest.nuke!
+      else
+        raise Breakfast::ManifestDisabledError
+      end
+    end
+  end
+end
+
+module Breakfast
+  class ManifestDisabledError < StandardError
+    def initialize
+      super(
+        <<~ERROR
+          Rails.configuration.breakfast.manifest is set to false. 
+          Enable it by adding the following in your environment file:
+
+            config.breakfast.manifest.digest = true
+
+          *Note* by default digest is set to false in development and test enviornments.
+
+        ERROR
+      )
+    end
+  end
+end

--- a/node_package/package.json
+++ b/node_package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breakfast-rails",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Assets for the Breakfast Gem",
   "main": "./lib/breakfast-rails.js",
   "scripts": {

--- a/node_package/src/status-bar.js
+++ b/node_package/src/status-bar.js
@@ -211,7 +211,7 @@ class StatusBar {
           display: flex;
           flex-grow: 1;
           height: 30px;
-          padding: 8px;
+          padding: 0 8px;
         }
 
         .breakfast-status-bar .breakfast-message-log-error {

--- a/spec/acceptance/install_spec.rb
+++ b/spec/acceptance/install_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "Installing the Gem" do
       rails_dir = Dir.mktmpdir
 
       %x{rails new #{rails_dir}}
-      open("#{rails_dir}/Gemfile", "a") { gem "breakfast" }
+      open("#{rails_dir}/Gemfile", "a") { |file| file.write('gem "breakfast"') }
+
       %x{cd #{rails_dir} && bundle install}
       %x{cd #{rails_dir} && rails generate breakfast:install}
       %x{cd #{rails_dir} && node_modules/brunch/bin/brunch build}

--- a/spec/breakfast/compilation_listener_spec.rb
+++ b/spec/breakfast/compilation_listener_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Breakfast::CompilationListener do
   describe ".start" do
     it "will listen for changes to the asset output folder" do
       Breakfast::CompilationListener.start(
-        asset_output_folders: asset_dir,
+        asset_output_folder: asset_dir,
         source_code_folders: source_code_dir
       )
 
@@ -31,7 +31,7 @@ RSpec.describe Breakfast::CompilationListener do
 
     it "will listen for changes to the source code folders" do
       Breakfast::CompilationListener.start(
-        asset_output_folders: asset_dir,
+        asset_output_folder: asset_dir,
         source_code_folders: source_code_dir
       )
 
@@ -42,7 +42,7 @@ RSpec.describe Breakfast::CompilationListener do
 
         expect(Breakfast::CompilationListener).
           to have_received(:broadcast).with(
-            Breakfast::RELOAD_CHANNEL, 
+            Breakfast::RELOAD_CHANNEL,
             { extension: extension }
           )
 

--- a/spec/breakfast/manifest_spec.rb
+++ b/spec/breakfast/manifest_spec.rb
@@ -1,0 +1,117 @@
+require "spec_helper"
+require "tmpdir"
+require "json"
+
+RSpec.describe Breakfast::Manifest do
+  before do
+    allow_any_instance_of(Digest::MD5).to receive(:hexdigest).and_return("digest")
+    allow(SecureRandom).to receive(:hex) { "digest" }
+  end
+
+  let(:output_dir) { Dir.mktmpdir }
+
+  it "will generate a manifest file and comiple digested assets" do
+    Dir.mkdir("#{output_dir}/images/")
+
+    app_js = File.open("#{output_dir}/app.js", "w")
+    image = File.open("#{output_dir}/images/test.jpeg", "w")
+
+    manifest = Breakfast::Manifest.new(base_dir: output_dir)
+    manifest.digest!
+
+    expect(File).to exist("#{output_dir}/app.js")
+    expect(File).to exist("#{output_dir}/app-digest.js")
+
+    expect(File).to exist("#{output_dir}/images/test.jpeg")
+    expect(File).to exist("#{output_dir}/images/test-digest.jpeg")
+
+    expect(JSON.parse(File.read("#{output_dir}/.breakfast-manifest-digest.json"))).to eq({
+      "app.js" => "app-digest.js",
+      "images/test.jpeg" => "images/test-digest.jpeg"
+    })
+  end
+
+  it "will not fingerprint already fingerprinted assets" do
+    File.open("#{output_dir}/app-523a40ea7f96cd5740980e61d62dbc77.js", "w")
+
+    manifest = Breakfast::Manifest.new(base_dir: output_dir)
+    manifest.digest!
+
+    expect(File).to exist("#{output_dir}/app-523a40ea7f96cd5740980e61d62dbc77.js")
+    expect(number_of_files(output_dir)).to eq(1)
+  end
+
+  it "will find an existing manifest" do
+    File.open("#{output_dir}/.breakfast-manifest-869269cdf1773ff0dec91bafb37310ea.json", "w") do |file|
+      file.write({ "app.js" => "app-abc123.js" }.to_json)
+    end
+
+    manifest = Breakfast::Manifest.new(base_dir: output_dir)
+
+    expect(manifest.asset("app.js")).to eq("app-abc123.js")
+  end
+
+  it "will return the digested asset path for a given asset" do
+    Dir.mkdir("#{output_dir}/images/")
+
+    app_js = File.open("#{output_dir}/app.js", "w")
+    image = File.open("#{output_dir}/images/test.jpeg", "w")
+
+    manifest = Breakfast::Manifest.new(base_dir: output_dir)
+    manifest.digest!
+
+    expect(manifest.asset("app.js")).to eq("app-digest.js")
+    expect(manifest.asset("images/test.jpeg")).to eq("images/test-digest.jpeg")
+    expect(manifest.asset("doesnt-exist.png")).to be nil
+  end
+
+  it "will remove assets that are no longer referenced by the manifest" do
+    Dir.mkdir("#{output_dir}/images/")
+
+    File.open("#{output_dir}/outdated-523a40ea7f96cd5740980e61d62dbc77.js", "w")
+    File.open("#{output_dir}/app.js", "w")
+    File.open("#{output_dir}/images/test.jpeg", "w")
+    File.open("#{output_dir}/images/outdated-523a40ea7f96cd5740980e61d62dbc77.jpeg", "w")
+
+    manifest = Breakfast::Manifest.new(base_dir: output_dir)
+    manifest.digest!
+
+    expect { manifest.clean! }.to change { number_of_files(output_dir) }.by(-2)
+  end
+
+  it "will keep any assets that are referenced by a sprockets manifest" do
+    Dir.mkdir("#{output_dir}/images/")
+
+    File.open("#{output_dir}/outdated-523a40ea7f96cd5740980e61d62dbc77.js", "w")
+    File.open("#{output_dir}/app.js", "w")
+    File.open("#{output_dir}/images/test.jpeg", "w")
+    File.open("#{output_dir}/images/outdated-523a40ea7f96cd5740980e61d62dbc77.jpeg", "w")
+
+    File.open("#{output_dir}/sprockets-file-4e936bdd95c293bccbeefc56f191e4a7.js", "w")
+    File.open("#{output_dir}/.sprockets-manifest-4e936bdd95c293bccbeefc56f191e4a7.json", "w") do |file|
+      file.write({
+        "files" => {
+          "sprockets-file-4e936bdd95c293bccbeefc56f191e4a7.js" => {
+            "logical_path"=>"sprockets-file.js",
+            "mtime"=>"2016-10-26T18:26:19+00:00",
+            "size"=>97551,
+            "digest"=>"4e936bdd95c293bccbeefc56f191e4a7",
+            "integrity"=>"sha256-hTHBWGfDx5DSg9+fD8EiCDkSZOCUpE+CNFjiFhKmICZ="
+          }
+        },
+        "assets" => {
+          "sprockets-file.js" => "sprockets-file-4e936bdd95c293bccbeefc56f191e4a7"
+        }
+      }.to_json)
+    end
+
+    manifest = Breakfast::Manifest.new(base_dir: output_dir)
+    manifest.digest!
+
+    expect { manifest.clean! }.to change { number_of_files(output_dir) }.by(-2)
+  end
+
+  def number_of_files(dir)
+    Dir["#{dir}/**/*"].reject { |f| File.directory?(f) }.size
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "rails/all"
-require 'breakfast'
+require "breakfast"
 
 RSpec.configure do |config|
   config.disable_monkey_patching!


### PR DESCRIPTION
Fixes #3 

#### Upgrading to `0.4.0` from `0.3.0`
- Update gem with `bundle update breakfast`
- Bump the `breakfast-rails` version in `package.json` to `0.4.0`
- Run `npm install`

*Note* Now by default asset fingerprinting will be on by default in production.
A copy of each with the original filename will be present as well, so any
hard-coded links to assets will still work correctly.

#### Added
- Asset Digests. Now when deploying assets will have fingerprints added to their
  file names. This allows browsers to aggressively cache your assets.
- New Option: `breakfast.manifest.digest`. Defaults to false in development /
  test and true everywhere else. When true, enables Rails to serve fingerprinted
  assets.
- Rake Commands to trigger certain behavior:
  - `breakfast:assets:build`
    Manually run a compilation step.
  - `breakfast:assets:build_production`
    Manually trigger a production build. This will cause assets to get minified.
  - `breakfast:assets:digest`
    Run through your compiled assets and add a fingerprint to each one. Creates
    a copy, leaving a file with the original filename and a duplicate with an
    md5 fingerprint.
  - `breakfast:assets:clean`
    Removes any assets from the output folder that are not specified in the
    manifest file (removes out of date files).
  - `breakfast:assets:nuke`
    Removes manifest and fingerprinted assets from the output folder.
- New Capistrano Option: `:breakfast_npm_install_command`
  Defaults to just `install`. Can be overridden to redirect output to dev/null.
  Example:

  ```
  set :breakfast_npm_install_command, "install > /dev/null 2>&1"
  ```

#### Changes
- Fixed small CSS issue if box-sizing is not set border-box globally.


#### Contributors
Many many thanks to the contributors for this release!
- [@patkoperwas](https://github.com/patkoperwas)
- [@mikeastock](https://github.com/mikeastock)
- [@HParker](https://github.com/HParker)