### PR TITLE
add babel-brunch to required packages

### DIFF
--- a/lib/generators/breakfast/install_generator.rb
+++ b/lib/generators/breakfast/install_generator.rb
@@ -61,7 +61,7 @@ module Breakfast
 
       def install_required_packages
         run "yarn add actioncable breakfast-rails jquery jquery-ujs turbolinks"
-        run "yarn add --dev brunch babel brunch clean-css-brunch sass-brunch uglify-js-brunch"
+        run "yarn add --dev brunch babel babel-brunch clean-css-brunch sass-brunch uglify-js-brunch"
       end
 
       def create_directory_structure


### PR DESCRIPTION
Guess this is a typo. The brunch package is twice in the list and without the babel-brunch package js files actually do not go through babel. Was getting a "Unexpected token import" after setting everything up.