### PR TITLE
Remove potential double yarn install

### DIFF
--- a/lib/generators/breakfast/install_generator.rb
+++ b/lib/generators/breakfast/install_generator.rb
@@ -60,8 +60,20 @@ module Breakfast
       end
 
       def install_required_packages
-        run "yarn add actioncable breakfast-rails jquery jquery-ujs turbolinks"
-        run "yarn add --dev brunch babel babel-brunch clean-css-brunch sass-brunch uglify-js-brunch"
+        packages = %w(
+          actioncable
+          babel
+          babel-brunch
+          breakfast-rails
+          brunch
+          clean-css-brunch
+          jquery
+          jquery-ujs
+          sass-brunch
+          turbolinks
+          uglify-js-brunch
+        )
+        run "yarn add #{packages.join(' ')}"
       end
 
       def create_directory_structure

--- a/lib/tasks/breakfast.rake
+++ b/lib/tasks/breakfast.rake
@@ -58,7 +58,10 @@ end
 
 if Rake::Task.task_defined?("assets:precompile")
   Rake::Task["assets:precompile"].enhance do
-    Rake::Task["breakfast:yarn:install"].execute
+    unless Rake::Task.task_defined?("yarn:install")
+      # Rails 5.1 includes a yarn install command - don't yarn install twice.
+      Rake::Task["breakfast:yarn:install"].execute
+    end
     Rake::Task["breakfast:assets:compile"].execute
   end
 end

--- a/lib/tasks/breakfast.rake
+++ b/lib/tasks/breakfast.rake
@@ -58,7 +58,7 @@ end
 
 if Rake::Task.task_defined?("assets:precompile")
   Rake::Task["assets:precompile"].enhance do
-    unless Rake::Task.task_defined?("yarn:install")
+    unless File.exist?("./bin/yarn") && Rake::Task.task_defined?("yarn:install")
       # Rails 5.1 includes a yarn install command - don't yarn install twice.
       Rake::Task["breakfast:yarn:install"].invoke
     end

--- a/lib/tasks/breakfast.rake
+++ b/lib/tasks/breakfast.rake
@@ -60,10 +60,14 @@ if Rake::Task.task_defined?("assets:precompile")
   Rake::Task["assets:precompile"].enhance do
     unless Rake::Task.task_defined?("yarn:install")
       # Rails 5.1 includes a yarn install command - don't yarn install twice.
-      Rake::Task["breakfast:yarn:install"].execute
+      Rake::Task["breakfast:yarn:install"].invoke
     end
-    Rake::Task["breakfast:assets:compile"].execute
+    Rake::Task["breakfast:assets:compile"].invoke
   end
+else
+  Rake::Task.define_task(
+    "assets:precompile" => ["breakfast:yarn", "breakfast:assets:compile"]
+  )
 end
 
 module Breakfast


### PR DESCRIPTION
Rails 5.1 ships with a bin/yarn command, which gets invoked during assets:precompile. Which means that in 5.1 `yarn` is being run twice (once by Rails, and once by Breakfast). 

However, have to deal with the edge case of someone upgrading to 5.1 from 5.0 - in those cases they may not have generated the yarn binstub.

Got a little ahead of myself and went ahead and added a fallback definition for `assets:precompile`, in the case that someone is running Rails without sprockets.