### PR TITLE
Make brunch command configurable by ENV var.

### DIFF
--- a/lib/breakfast/brunch_watcher.rb
+++ b/lib/breakfast/brunch_watcher.rb
@@ -2,7 +2,7 @@ require "pty"
 
 module Breakfast
   class BrunchWatcher
-    BRUNCH_COMMAND = "./node_modules/brunch/bin/brunch watch".freeze
+    BRUNCH_COMMAND = "#{Breakfast::BRUNCH_COMMAND} watch".freeze
 
     attr_accessor :pid
     attr_reader :log

--- a/lib/breakfast/constants.rb
+++ b/lib/breakfast/constants.rb
@@ -1,0 +1,3 @@
+module Breakfast
+  BRUNCH_COMMAND = ENV['BRUNCH_PATH'] || './node_modules/brunch/bin/brunch'
+end

--- a/lib/tasks/breakfast.rake
+++ b/lib/tasks/breakfast.rake
@@ -12,12 +12,12 @@ namespace :breakfast do
 
     desc "Build assets for production"
     task build_production: :environment do
-      Breakfast.call_system "NODE_ENV=production ./node_modules/brunch/bin/brunch build --production"
+      Breakfast.call_system "NODE_ENV=production #{Breakfast::BRUNCH_COMMAND} build --production"
     end
 
     desc "Build assets"
     task build: :environment do
-      Breakfast.call_system "./node_modules/brunch/bin/brunch build"
+      Breakfast.call_system "#{Breakfast::BRUNCH_COMMAND} build"
     end
 
     desc "Add a digest to non-fingerprinted assets"


### PR DESCRIPTION
Issue:

`assets:precompile` installs npm dependencies with `NODE_ENV=production` but the path breakfast uses to invoke `brunch` is in local npm modules i.e. `./node_modules/brunch/bin/brunch`. In our production environment, we want to run `assets:precompile`, but don't want to include `brunch` in our dependencies (only in dev. dependencies. However, being able to pass the `brunch` path in as an ENV var allows us to globally install brunch via `npm install -g brunch` in our Dockerfile and use this global binary as the brunch command path.