### PR TITLE
Update actioncable version

### DIFF
--- a/breakfast.gemspec
+++ b/breakfast.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency "rails", ">= 5.0"
-  spec.add_dependency "actioncable", "~> 5.0"
+  spec.add_dependency "actioncable", ">= 5.0"
   spec.add_dependency "listen", ">= 3.0"
 end


### PR DESCRIPTION
Replaces the pessimistic version constraint on actioncable to be the same as for rails (>= 5.0)
to allow Rails 6 beta/rc.